### PR TITLE
chore: remove copyright notice in the header of each file and navigate to license files instead

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -56,12 +56,14 @@ mlc --ignore-path target
 ''']
 
 [tasks.copyright]
-script = ['''
+script = [
+  '''
 #!/usr/bin/env bash -eux
 for rs in $(git ls-files |grep -e '\.rs$') ; do
-  grep '// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.' $rs
+  grep '// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.' $rs
 done
-''']
+''',
+]
 
 [tasks.publish]
 script = [

--- a/foreign-service/src/lib.rs
+++ b/foreign-service/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 //! Provides pseudo foreign services to springql-core for testing purpose.
 

--- a/foreign-service/src/sink.rs
+++ b/foreign-service/src/sink.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use anyhow::Result;
 use std::io::{BufRead, BufReader};

--- a/foreign-service/src/source.rs
+++ b/foreign-service/src/source.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub mod source_input;
 

--- a/foreign-service/src/source/source_input.rs
+++ b/foreign-service/src/source/source_input.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub mod timed_stream;
 

--- a/foreign-service/src/source/source_input/timed_stream.rs
+++ b/foreign-service/src/source/source_input/timed_stream.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub mod file_type;
 

--- a/foreign-service/src/source/source_input/timed_stream/file_parser.rs
+++ b/foreign-service/src/source/source_input/timed_stream/file_parser.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use anyhow::Result;
 use std::{fs::File, path::Path};

--- a/foreign-service/src/source/source_input/timed_stream/file_type.rs
+++ b/foreign-service/src/source/source_input/timed_stream/file_type.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 #[derive(Eq, PartialEq, Debug)]
 pub enum FileType {

--- a/foreign-service/src/source/source_input/timed_stream/timer.rs
+++ b/foreign-service/src/source/source_input/timed_stream/timer.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use chrono::{DateTime, Duration, Utc};
 

--- a/springql-core/examples/demo_pipeline.rs
+++ b/springql-core/examples/demo_pipeline.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::{
     io::copy,

--- a/springql-core/src/api.rs
+++ b/springql-core/src/api.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub mod error;
 pub mod high_level_rs;

--- a/springql-core/src/api/error.rs
+++ b/springql-core/src/api/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 //! Error type.
 

--- a/springql-core/src/api/error/foreign_info.rs
+++ b/springql-core/src/api/error/foreign_info.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 //! Foreign system information for error reporting.
 

--- a/springql-core/src/api/high_level_rs.rs
+++ b/springql-core/src/api/high_level_rs.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 //! High-level Rust API to execute / register SpringQL from Rust.
 

--- a/springql-core/src/api/low_level_rs.rs
+++ b/springql-core/src/api/low_level_rs.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 //! Low-level API functions to execute / register SpringQL from Rust.
 //!

--- a/springql-core/src/api/low_level_rs/engine_mutex.rs
+++ b/springql-core/src/api/low_level_rs/engine_mutex.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::sync::{Arc, Mutex, MutexGuard};
 

--- a/springql-core/src/api/low_level_rs/spring_config.rs
+++ b/springql-core/src/api/low_level_rs/spring_config.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use serde::Deserialize;
 

--- a/springql-core/src/expr_resolver.rs
+++ b/springql-core/src/expr_resolver.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(crate) mod expr_label;
 

--- a/springql-core/src/expr_resolver/expr_label.rs
+++ b/springql-core/src/expr_resolver/expr_label.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 #[derive(Clone, Eq, PartialEq, Debug, Default)]
 pub(crate) struct ExprLabelGenerator {

--- a/springql-core/src/expression.rs
+++ b/springql-core/src/expression.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 //! Expression has two forms:
 //!

--- a/springql-core/src/expression/boolean_expression.rs
+++ b/springql-core/src/expression/boolean_expression.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(crate) mod comparison_function;
 pub(crate) mod logical_function;

--- a/springql-core/src/expression/boolean_expression/comparison_function.rs
+++ b/springql-core/src/expression/boolean_expression/comparison_function.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::expression::ValueExprType;
 

--- a/springql-core/src/expression/boolean_expression/logical_function.rs
+++ b/springql-core/src/expression/boolean_expression/logical_function.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::expression::ValueExprType;
 

--- a/springql-core/src/expression/boolean_expression/numerical_function.rs
+++ b/springql-core/src/expression/boolean_expression/numerical_function.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::expression::ValueExprType;
 

--- a/springql-core/src/expression/function_call.rs
+++ b/springql-core/src/expression/function_call.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use super::ValueExprType;
 

--- a/springql-core/src/expression/operator.rs
+++ b/springql-core/src/expression/operator.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 /// unary operator for an expression
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]

--- a/springql-core/src/lib.rs
+++ b/springql-core/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 //! SpringQL-core implementation.
 //!

--- a/springql-core/src/mem_size.rs
+++ b/springql-core/src/mem_size.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 /// This trait requires estimation on how much heap memory [bytes] used by impl queue.
 ///

--- a/springql-core/src/pipeline.rs
+++ b/springql-core/src/pipeline.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 //! # Pipeline concept diagram
 //!

--- a/springql-core/src/pipeline/field.rs
+++ b/springql-core/src/pipeline/field.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 //! A field is a part of a tuple.
 //! Types of fields are:

--- a/springql-core/src/pipeline/field/field_name.rs
+++ b/springql-core/src/pipeline/field/field_name.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::{
     mem_size::MemSize,

--- a/springql-core/src/pipeline/name.rs
+++ b/springql-core/src/pipeline/name.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::fmt::Display;
 

--- a/springql-core/src/pipeline/option.rs
+++ b/springql-core/src/pipeline/option.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(crate) mod options_builder;
 

--- a/springql-core/src/pipeline/option/in_memory_queue_options.rs
+++ b/springql-core/src/pipeline/option/in_memory_queue_options.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::{
     error::{Result, SpringError},

--- a/springql-core/src/pipeline/option/net_options.rs
+++ b/springql-core/src/pipeline/option/net_options.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::net::IpAddr;
 

--- a/springql-core/src/pipeline/option/options_builder.rs
+++ b/springql-core/src/pipeline/option/options_builder.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::collections::HashMap;
 

--- a/springql-core/src/pipeline/pipeline_graph.rs
+++ b/springql-core/src/pipeline/pipeline_graph.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 //! Pipeline is the most important structural view of stream processing, similar to RDBMS's ER-diagram.
 //!

--- a/springql-core/src/pipeline/pipeline_graph/edge.rs
+++ b/springql-core/src/pipeline/pipeline_graph/edge.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::sync::Arc;
 

--- a/springql-core/src/pipeline/pipeline_graph/stream_node.rs
+++ b/springql-core/src/pipeline/pipeline_graph/stream_node.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::sync::Arc;
 

--- a/springql-core/src/pipeline/pipeline_version.rs
+++ b/springql-core/src/pipeline/pipeline_version.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use serde::{Deserialize, Serialize};
 

--- a/springql-core/src/pipeline/pump_model.rs
+++ b/springql-core/src/pipeline/pump_model.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(crate) mod pump_input_type;
 pub(crate) mod window_operation_parameter;

--- a/springql-core/src/pipeline/pump_model/pump_input_type.rs
+++ b/springql-core/src/pipeline/pump_model/pump_input_type.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use serde::{Deserialize, Serialize};
 

--- a/springql-core/src/pipeline/pump_model/window_operation_parameter.rs
+++ b/springql-core/src/pipeline/pump_model/window_operation_parameter.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(crate) mod aggregate;
 pub(crate) mod join_parameter;

--- a/springql-core/src/pipeline/pump_model/window_operation_parameter/aggregate.rs
+++ b/springql-core/src/pipeline/pump_model/window_operation_parameter/aggregate.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::expr_resolver::expr_label::{AggrExprLabel, ValueExprLabel};
 

--- a/springql-core/src/pipeline/pump_model/window_operation_parameter/join_parameter.rs
+++ b/springql-core/src/pipeline/pump_model/window_operation_parameter/join_parameter.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::{
     expr_resolver::expr_label::ValueExprLabel, pipeline::field::field_name::ColumnReference,

--- a/springql-core/src/pipeline/pump_model/window_parameter.rs
+++ b/springql-core/src/pipeline/pump_model/window_parameter.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::stream_engine::time::duration::event_duration::EventDuration;
 

--- a/springql-core/src/pipeline/relation.rs
+++ b/springql-core/src/pipeline/relation.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(crate) mod column;
 pub(crate) mod sql_type;

--- a/springql-core/src/pipeline/relation/column.rs
+++ b/springql-core/src/pipeline/relation/column.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(crate) mod column_constraint;
 pub(crate) mod column_data_type;

--- a/springql-core/src/pipeline/relation/column/column_constraint.rs
+++ b/springql-core/src/pipeline/relation/column/column_constraint.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use serde::{Deserialize, Serialize};
 

--- a/springql-core/src/pipeline/relation/column/column_data_type.rs
+++ b/springql-core/src/pipeline/relation/column/column_data_type.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use serde::{Deserialize, Serialize};
 

--- a/springql-core/src/pipeline/relation/column/column_definition.rs
+++ b/springql-core/src/pipeline/relation/column/column_definition.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use serde::{Deserialize, Serialize};
 

--- a/springql-core/src/pipeline/relation/sql_type.rs
+++ b/springql-core/src/pipeline/relation/sql_type.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use serde::{Deserialize, Serialize};
 

--- a/springql-core/src/pipeline/sink_writer_model.rs
+++ b/springql-core/src/pipeline/sink_writer_model.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(crate) mod sink_writer_type;
 

--- a/springql-core/src/pipeline/sink_writer_model/sink_writer_type.rs
+++ b/springql-core/src/pipeline/sink_writer_model/sink_writer_type.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use serde::{Deserialize, Serialize};
 

--- a/springql-core/src/pipeline/source_reader_model.rs
+++ b/springql-core/src/pipeline/source_reader_model.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(crate) mod source_reader_type;
 

--- a/springql-core/src/pipeline/source_reader_model/source_reader_type.rs
+++ b/springql-core/src/pipeline/source_reader_model/source_reader_type.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use serde::{Deserialize, Serialize};
 

--- a/springql-core/src/pipeline/stream_model.rs
+++ b/springql-core/src/pipeline/stream_model.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(crate) mod stream_shape;
 

--- a/springql-core/src/pipeline/stream_model/stream_shape.rs
+++ b/springql-core/src/pipeline/stream_model/stream_shape.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use anyhow::{anyhow, Context};
 use serde::{Deserialize, Serialize};

--- a/springql-core/src/pipeline/test_support.rs
+++ b/springql-core/src/pipeline/test_support.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(crate) mod factory;
 pub(crate) mod fixture;

--- a/springql-core/src/pipeline/test_support/factory.rs
+++ b/springql-core/src/pipeline/test_support/factory.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::{
     expression::{

--- a/springql-core/src/pipeline/test_support/fixture.rs
+++ b/springql-core/src/pipeline/test_support/fixture.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::{net::IpAddr, sync::Arc};
 

--- a/springql-core/src/sql_processor.rs
+++ b/springql-core/src/sql_processor.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(crate) mod sql_parser;
 

--- a/springql-core/src/sql_processor/query_planner.rs
+++ b/springql-core/src/sql_processor/query_planner.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 //! Translates `SelectSyntax` into `ExprResolver` and `QueryPlan`.
 //!

--- a/springql-core/src/sql_processor/query_planner/select_syntax_analyzer.rs
+++ b/springql-core/src/sql_processor/query_planner/select_syntax_analyzer.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::sql_processor::sql_parser::syntax::SelectStreamSyntax;
 

--- a/springql-core/src/sql_processor/query_planner/select_syntax_analyzer/field.rs
+++ b/springql-core/src/sql_processor/query_planner/select_syntax_analyzer/field.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use super::SelectSyntaxAnalyzer;
 use crate::sql_processor::sql_parser::syntax::SelectFieldSyntax;

--- a/springql-core/src/sql_processor/query_planner/select_syntax_analyzer/from_item.rs
+++ b/springql-core/src/sql_processor/query_planner/select_syntax_analyzer/from_item.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use super::SelectSyntaxAnalyzer;
 use crate::{

--- a/springql-core/src/sql_processor/query_planner/select_syntax_analyzer/group_aggregate.rs
+++ b/springql-core/src/sql_processor/query_planner/select_syntax_analyzer/group_aggregate.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use super::SelectSyntaxAnalyzer;
 use crate::sql_processor::sql_parser::syntax::GroupingElementSyntax;

--- a/springql-core/src/sql_processor/query_planner/select_syntax_analyzer/window.rs
+++ b/springql-core/src/sql_processor/query_planner/select_syntax_analyzer/window.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use super::SelectSyntaxAnalyzer;
 

--- a/springql-core/src/sql_processor/sql_parser.rs
+++ b/springql-core/src/sql_processor/sql_parser.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(crate) mod syntax;
 

--- a/springql-core/src/sql_processor/sql_parser/parse_success.rs
+++ b/springql-core/src/sql_processor/sql_parser/parse_success.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::{
     pipeline::{

--- a/springql-core/src/sql_processor/sql_parser/pest_parser_impl.rs
+++ b/springql-core/src/sql_processor/sql_parser/pest_parser_impl.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 mod generated_parser;
 mod helper;

--- a/springql-core/src/sql_processor/sql_parser/pest_parser_impl/generated_parser.rs
+++ b/springql-core/src/sql_processor/sql_parser/pest_parser_impl/generated_parser.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use pest_derive::Parser;
 

--- a/springql-core/src/sql_processor/sql_parser/pest_parser_impl/helper.rs
+++ b/springql-core/src/sql_processor/sql_parser/pest_parser_impl/helper.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use super::generated_parser::Rule;
 use crate::error::{Result, SpringError};

--- a/springql-core/src/sql_processor/sql_parser/syntax.rs
+++ b/springql-core/src/sql_processor/sql_parser/syntax.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::{
     expression::{AggrExpr, ValueExpr},

--- a/springql-core/src/stream_engine.rs
+++ b/springql-core/src/stream_engine.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 //! Stream Engine component.
 //!

--- a/springql-core/src/stream_engine/autonomous_executor.rs
+++ b/springql-core/src/stream_engine/autonomous_executor.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(crate) mod row;
 pub(crate) mod task;

--- a/springql-core/src/stream_engine/autonomous_executor/event_queue.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/event_queue.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 //! This mod provides event queue mechanism.
 //!

--- a/springql-core/src/stream_engine/autonomous_executor/event_queue/event.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/event_queue/event.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 //! # Events diagram
 //!

--- a/springql-core/src/stream_engine/autonomous_executor/memory_state_machine.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/memory_state_machine.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 //! ![Memory state machine](https://raw.githubusercontent.com/SpringQL/SpringQL.github.io/main/static/img/memory-state-machine-and-effect.svg)
 

--- a/springql-core/src/stream_engine/autonomous_executor/memory_state_machine_worker.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/memory_state_machine_worker.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 //! Memory State Machine has 3 states: Moderate, Severe, and Critical.
 //! State transition occurs when task executor's memory usage cross the threshold.

--- a/springql-core/src/stream_engine/autonomous_executor/memory_state_machine_worker/memory_state_machine_worker_thread.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/memory_state_machine_worker/memory_state_machine_worker_thread.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::{sync::Arc, thread, time::Duration};
 

--- a/springql-core/src/stream_engine/autonomous_executor/performance_metrics.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/performance_metrics.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(in crate::stream_engine::autonomous_executor) mod performance_metrics_summary;
 

--- a/springql-core/src/stream_engine/autonomous_executor/performance_metrics/calculation.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/performance_metrics/calculation.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::{
     cmp::max,

--- a/springql-core/src/stream_engine/autonomous_executor/performance_metrics/metrics_update_command.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/performance_metrics/metrics_update_command.rs
@@ -1,3 +1,3 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(in crate::stream_engine::autonomous_executor) mod metrics_update_by_task_execution;

--- a/springql-core/src/stream_engine/autonomous_executor/performance_metrics/metrics_update_command/metrics_update_by_task_execution.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/performance_metrics/metrics_update_command/metrics_update_by_task_execution.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::ops::Add;
 

--- a/springql-core/src/stream_engine/autonomous_executor/performance_metrics/performance_metrics_summary.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/performance_metrics/performance_metrics_summary.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::fmt::Display;
 

--- a/springql-core/src/stream_engine/autonomous_executor/performance_metrics/queue_metrics.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/performance_metrics/queue_metrics.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(in crate::stream_engine::autonomous_executor) mod row_queue_metrics;
 pub(in crate::stream_engine::autonomous_executor) mod window_queue_metrics;

--- a/springql-core/src/stream_engine/autonomous_executor/performance_metrics/queue_metrics/row_queue_metrics.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/performance_metrics/queue_metrics/row_queue_metrics.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use serde::{Deserialize, Serialize};
 

--- a/springql-core/src/stream_engine/autonomous_executor/performance_metrics/queue_metrics/window_queue_metrics.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/performance_metrics/queue_metrics/window_queue_metrics.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use serde::{Deserialize, Serialize};
 

--- a/springql-core/src/stream_engine/autonomous_executor/performance_metrics/task_metrics.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/performance_metrics/task_metrics.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use serde::{Deserialize, Serialize};
 

--- a/springql-core/src/stream_engine/autonomous_executor/performance_monitor_worker.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/performance_monitor_worker.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(in crate::stream_engine::autonomous_executor) mod performance_monitor_worker_thread;
 

--- a/springql-core/src/stream_engine/autonomous_executor/performance_monitor_worker/performance_monitor_worker_thread.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/performance_monitor_worker/performance_monitor_worker_thread.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::{sync::Arc, thread, time::Duration};
 

--- a/springql-core/src/stream_engine/autonomous_executor/performance_monitor_worker/web_console_reporter.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/performance_monitor_worker/web_console_reporter.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 mod web_console_request;
 

--- a/springql-core/src/stream_engine/autonomous_executor/performance_monitor_worker/web_console_reporter/web_console_request.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/performance_monitor_worker/web_console_reporter/web_console_request.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use serde_json::json;
 

--- a/springql-core/src/stream_engine/autonomous_executor/pipeline_derivatives.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/pipeline_derivatives.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 mod task_repository;
 

--- a/springql-core/src/stream_engine/autonomous_executor/pipeline_derivatives/task_repository.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/pipeline_derivatives/task_repository.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::{borrow::BorrowMut, collections::HashMap, sync::Arc};
 

--- a/springql-core/src/stream_engine/autonomous_executor/purger_worker.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/purger_worker.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(in crate::stream_engine::autonomous_executor) mod purger_worker_thread;
 

--- a/springql-core/src/stream_engine/autonomous_executor/purger_worker/purger_worker_thread.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/purger_worker/purger_worker_thread.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::{sync::Arc, thread, time::Duration};
 

--- a/springql-core/src/stream_engine/autonomous_executor/queue.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/queue.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(in crate::stream_engine::autonomous_executor) mod row_queue;
 pub(in crate::stream_engine::autonomous_executor) mod row_queue_repository;

--- a/springql-core/src/stream_engine/autonomous_executor/queue/row_queue.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/queue/row_queue.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::{collections::VecDeque, sync::Mutex};
 

--- a/springql-core/src/stream_engine/autonomous_executor/queue/row_queue_repository.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/queue/row_queue_repository.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::{
     collections::{HashMap, HashSet},

--- a/springql-core/src/stream_engine/autonomous_executor/queue/window_queue.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/queue/window_queue.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::{collections::VecDeque, sync::Mutex};
 

--- a/springql-core/src/stream_engine/autonomous_executor/queue/window_queue_repository.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/queue/window_queue_repository.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::{
     collections::{HashMap, HashSet},

--- a/springql-core/src/stream_engine/autonomous_executor/repositories.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/repositories.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::low_level_rs::SpringConfig;
 

--- a/springql-core/src/stream_engine/autonomous_executor/row.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(crate) mod value;
 

--- a/springql-core/src/stream_engine/autonomous_executor/row/column.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/column.rs
@@ -1,3 +1,3 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(in crate::stream_engine::autonomous_executor) mod stream_column;

--- a/springql-core/src/stream_engine/autonomous_executor/row/column/stream_column.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/column/stream_column.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use anyhow::{anyhow, Context};
 

--- a/springql-core/src/stream_engine/autonomous_executor/row/column_values.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/column_values.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::{
     error::{Result, SpringError},

--- a/springql-core/src/stream_engine/autonomous_executor/row/foreign_row.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/foreign_row.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(in crate::stream_engine) mod format;
 pub(in crate::stream_engine) mod sink_row;

--- a/springql-core/src/stream_engine/autonomous_executor/row/foreign_row/format.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/foreign_row/format.rs
@@ -1,3 +1,3 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(in crate::stream_engine) mod json;

--- a/springql-core/src/stream_engine/autonomous_executor/row/foreign_row/format/json.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/foreign_row/format/json.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use anyhow::Context;
 

--- a/springql-core/src/stream_engine/autonomous_executor/row/foreign_row/sink_row.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/foreign_row/sink_row.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use super::format::json::JsonObject;
 use crate::error::Result;

--- a/springql-core/src/stream_engine/autonomous_executor/row/foreign_row/source_row.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/foreign_row/source_row.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::sync::Arc;
 

--- a/springql-core/src/stream_engine/autonomous_executor/row/row_repository/naive_row_repository.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/row_repository/naive_row_repository.rs
@@ -1,1 +1,1 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.

--- a/springql-core/src/stream_engine/autonomous_executor/row/value.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/value.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(crate) mod sql_convertible;
 pub(crate) mod sql_value;

--- a/springql-core/src/stream_engine/autonomous_executor/row/value/sql_convertible.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/value/sql_convertible.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 mod boolean;
 mod event_duration;

--- a/springql-core/src/stream_engine/autonomous_executor/row/value/sql_convertible/boolean.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/value/sql_convertible/boolean.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::{
     error::Result,

--- a/springql-core/src/stream_engine/autonomous_executor/row/value/sql_convertible/event_duration.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/value/sql_convertible/event_duration.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::{
     error::Result,

--- a/springql-core/src/stream_engine/autonomous_executor/row/value/sql_convertible/float.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/value/sql_convertible/float.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use ordered_float::OrderedFloat;
 

--- a/springql-core/src/stream_engine/autonomous_executor/row/value/sql_convertible/int.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/value/sql_convertible/int.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use anyhow::Context;
 

--- a/springql-core/src/stream_engine/autonomous_executor/row/value/sql_convertible/text.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/value/sql_convertible/text.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::{
     error::Result,

--- a/springql-core/src/stream_engine/autonomous_executor/row/value/sql_convertible/timestamp.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/value/sql_convertible/timestamp.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::{
     error::Result,

--- a/springql-core/src/stream_engine/autonomous_executor/row/value/sql_value.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/value/sql_value.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(crate) mod nn_sql_value;
 pub(crate) mod sql_compare_result;

--- a/springql-core/src/stream_engine/autonomous_executor/row/value/sql_value/nn_sql_value.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/value/sql_value/nn_sql_value.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::mem::size_of;
 use std::ops::{Add, Mul};

--- a/springql-core/src/stream_engine/autonomous_executor/row/value/sql_value/sql_compare_result.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/value/sql_value/sql_compare_result.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::cmp::Ordering;
 

--- a/springql-core/src/stream_engine/autonomous_executor/row/value/sql_value/sql_value_hash_key.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/value/sql_value/sql_value_hash_key.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};

--- a/springql-core/src/stream_engine/autonomous_executor/task.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(crate) mod tuple;
 

--- a/springql-core/src/stream_engine/autonomous_executor/task/pump_task.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/pump_task.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 mod pump_subtask;
 

--- a/springql-core/src/stream_engine/autonomous_executor/task/pump_task/pump_subtask.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/pump_task/pump_subtask.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(in crate::stream_engine::autonomous_executor) mod insert_subtask;
 pub(in crate::stream_engine::autonomous_executor) mod query_subtask;

--- a/springql-core/src/stream_engine/autonomous_executor/task/pump_task/pump_subtask/insert_subtask.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/pump_task/pump_subtask/insert_subtask.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::sync::Arc;
 

--- a/springql-core/src/stream_engine/autonomous_executor/task/pump_task/pump_subtask/query_subtask.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/pump_task/pump_subtask/query_subtask.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(super) mod aggr_projection_subtask;
 pub(super) mod collect_subtask;

--- a/springql-core/src/stream_engine/autonomous_executor/task/pump_task/pump_subtask/query_subtask/aggr_projection_subtask.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/pump_task/pump_subtask/query_subtask/aggr_projection_subtask.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::error::Result;
 use crate::expr_resolver::expr_label::{AggrExprLabel, ValueExprLabel};

--- a/springql-core/src/stream_engine/autonomous_executor/task/pump_task/pump_subtask/query_subtask/collect_subtask.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/pump_task/pump_subtask/query_subtask/collect_subtask.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::sync::Arc;
 

--- a/springql-core/src/stream_engine/autonomous_executor/task/pump_task/pump_subtask/query_subtask/group_aggregate_window_subtask.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/pump_task/pump_subtask/query_subtask/group_aggregate_window_subtask.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::sync::{Mutex, MutexGuard};
 

--- a/springql-core/src/stream_engine/autonomous_executor/task/pump_task/pump_subtask/query_subtask/join_subtask.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/pump_task/pump_subtask/query_subtask/join_subtask.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::sync::{Mutex, MutexGuard};
 

--- a/springql-core/src/stream_engine/autonomous_executor/task/pump_task/pump_subtask/query_subtask/value_projection_subtask.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/pump_task/pump_subtask/query_subtask/value_projection_subtask.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::error::Result;
 use crate::expr_resolver::expr_label::ValueExprLabel;

--- a/springql-core/src/stream_engine/autonomous_executor/task/sink_task.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/sink_task.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(in crate::stream_engine::autonomous_executor) mod sink_writer;
 

--- a/springql-core/src/stream_engine/autonomous_executor/task/sink_task/sink_writer.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/sink_task/sink_writer.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::error::Result;
 use crate::low_level_rs::SpringSinkWriterConfig;

--- a/springql-core/src/stream_engine/autonomous_executor/task/sink_task/sink_writer/in_memory_queue.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/sink_task/sink_writer/in_memory_queue.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::error::Result;
 use crate::low_level_rs::SpringSinkWriterConfig;

--- a/springql-core/src/stream_engine/autonomous_executor/task/sink_task/sink_writer/net.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/sink_task/sink_writer/net.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::{
     io::{BufWriter, Write},

--- a/springql-core/src/stream_engine/autonomous_executor/task/sink_task/sink_writer/sink_writer_factory.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/sink_task/sink_writer/sink_writer_factory.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::error::Result;
 use crate::low_level_rs::SpringSinkWriterConfig;

--- a/springql-core/src/stream_engine/autonomous_executor/task/sink_task/sink_writer/sink_writer_repository.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/sink_task/sink_writer/sink_writer_repository.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::{
     collections::HashMap,

--- a/springql-core/src/stream_engine/autonomous_executor/task/source_task.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/source_task.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(in crate::stream_engine::autonomous_executor) mod source_reader;
 

--- a/springql-core/src/stream_engine/autonomous_executor/task/source_task/source_reader.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/source_task/source_reader.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::{
     error::Result, low_level_rs::SpringSourceReaderConfig, pipeline::option::Options,

--- a/springql-core/src/stream_engine/autonomous_executor/task/source_task/source_reader/net_client.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/source_task/source_reader/net_client.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::{
     io::{self, BufRead, BufReader},

--- a/springql-core/src/stream_engine/autonomous_executor/task/source_task/source_reader/net_server.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/source_task/source_reader/net_server.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::{
     io::{BufRead, BufReader},

--- a/springql-core/src/stream_engine/autonomous_executor/task/source_task/source_reader/source_reader_factory.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/source_task/source_reader/source_reader_factory.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::error::Result;
 use crate::low_level_rs::SpringSourceReaderConfig;

--- a/springql-core/src/stream_engine/autonomous_executor/task/source_task/source_reader/source_reader_repository.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/source_task/source_reader/source_reader_repository.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::{
     collections::HashMap,

--- a/springql-core/src/stream_engine/autonomous_executor/task/task_context.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/task_context.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::sync::Arc;
 

--- a/springql-core/src/stream_engine/autonomous_executor/task/tuple.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/tuple.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::{
     error::{Result, SpringError},

--- a/springql-core/src/stream_engine/autonomous_executor/task/window.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/window.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::{expr_resolver::ExprResolver, stream_engine::{Tuple, autonomous_executor::performance_metrics::metrics_update_command::metrics_update_by_task_execution::WindowInFlowByWindowTask}};
 

--- a/springql-core/src/stream_engine/autonomous_executor/task/window/aggregate.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/window/aggregate.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::{
     error::{Result, SpringError},

--- a/springql-core/src/stream_engine/autonomous_executor/task/window/join_window.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/window/join_window.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::pipeline::pump_model::{
     window_operation_parameter::{join_parameter::JoinParameter, WindowOperationParameter},

--- a/springql-core/src/stream_engine/autonomous_executor/task/window/panes.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/window/panes.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(in crate::stream_engine::autonomous_executor) mod pane;
 

--- a/springql-core/src/stream_engine/autonomous_executor/task/window/panes/pane.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/window/panes/pane.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::{
     expr_resolver::ExprResolver,

--- a/springql-core/src/stream_engine/autonomous_executor/task/window/panes/pane/aggregate_pane.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/window/panes/pane/aggregate_pane.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 mod aggregate_state;
 

--- a/springql-core/src/stream_engine/autonomous_executor/task/window/panes/pane/aggregate_pane/aggregate_state.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/window/panes/pane/aggregate_pane/aggregate_state.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 // TODO more generic avg
 #[derive(Debug, Default)]

--- a/springql-core/src/stream_engine/autonomous_executor/task/window/panes/pane/join_pane.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/window/panes/pane/join_pane.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::str::FromStr;
 

--- a/springql-core/src/stream_engine/autonomous_executor/task/window/watermark.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/window/watermark.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::cmp::max;
 

--- a/springql-core/src/stream_engine/autonomous_executor/task_executor.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_executor.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(in crate::stream_engine::autonomous_executor) mod task_executor_lock;
 pub(in crate::stream_engine::autonomous_executor) mod task_worker_thread_handler;

--- a/springql-core/src/stream_engine/autonomous_executor/task_executor/generic_worker_pool.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_executor/generic_worker_pool.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(super) mod generic_worker;
 

--- a/springql-core/src/stream_engine/autonomous_executor/task_executor/generic_worker_pool/generic_worker.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_executor/generic_worker_pool/generic_worker.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(in crate::stream_engine::autonomous_executor) mod generic_worker_thread;
 

--- a/springql-core/src/stream_engine/autonomous_executor/task_executor/generic_worker_pool/generic_worker/generic_worker_thread.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_executor/generic_worker_pool/generic_worker/generic_worker_thread.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 mod generic_worker_scheduler;
 

--- a/springql-core/src/stream_engine/autonomous_executor/task_executor/generic_worker_pool/generic_worker/generic_worker_thread/generic_worker_scheduler.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_executor/generic_worker_pool/generic_worker/generic_worker_thread/generic_worker_scheduler.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::stream_engine::autonomous_executor::{
     performance_metrics::PerformanceMetrics,

--- a/springql-core/src/stream_engine/autonomous_executor/task_executor/scheduler.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_executor/scheduler.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 //! A task graph is a DAG where nodes are `TaskId`s and edges are `QueueId`s.
 //!

--- a/springql-core/src/stream_engine/autonomous_executor/task_executor/scheduler/flow_efficient_scheduler.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_executor/scheduler/flow_efficient_scheduler.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 //! Flow-Efficient Scheduler, intended to minimize the size of working memory.
 //!

--- a/springql-core/src/stream_engine/autonomous_executor/task_executor/scheduler/memory_reducing_scheduler.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_executor/scheduler/memory_reducing_scheduler.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 //! Memory-Reducing Scheduler, intended to reducing working memory in task queues at the cost of fairness.
 //!

--- a/springql-core/src/stream_engine/autonomous_executor/task_executor/scheduler/source_scheduler.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_executor/scheduler/source_scheduler.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 //! Source Scheduler dedicating to schedule source tasks eagerly at Moderate and Severe state.
 

--- a/springql-core/src/stream_engine/autonomous_executor/task_executor/source_worker_pool.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_executor/source_worker_pool.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(super) mod source_worker;
 

--- a/springql-core/src/stream_engine/autonomous_executor/task_executor/source_worker_pool/source_worker.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_executor/source_worker_pool/source_worker.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(in crate::stream_engine::autonomous_executor) mod source_worker_thread;
 

--- a/springql-core/src/stream_engine/autonomous_executor/task_executor/source_worker_pool/source_worker/source_worker_thread.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_executor/source_worker_pool/source_worker/source_worker_thread.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::sync::Arc;
 

--- a/springql-core/src/stream_engine/autonomous_executor/task_executor/task_executor_lock.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_executor/task_executor_lock.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use anyhow::Context;
 

--- a/springql-core/src/stream_engine/autonomous_executor/task_executor/task_worker_thread_handler.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_executor/task_worker_thread_handler.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 //! Task execution logics commonly used by GenericWorkerThread and SourceWorkerThread.
 

--- a/springql-core/src/stream_engine/autonomous_executor/task_graph.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_graph.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 //! Task graph is most important runtime plan for task execution.
 //! Tasks are mapped to TaskGraph's nodes. queues are mapped to its nodes.

--- a/springql-core/src/stream_engine/autonomous_executor/task_graph/edge_ref.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_graph/edge_ref.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use petgraph::graph::NodeIndex;
 

--- a/springql-core/src/stream_engine/autonomous_executor/task_graph/queue_id.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_graph/queue_id.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(in crate::stream_engine::autonomous_executor) mod row_queue_id;
 pub(in crate::stream_engine::autonomous_executor) mod window_queue_id;

--- a/springql-core/src/stream_engine/autonomous_executor/task_graph/queue_id/row_queue_id.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_graph/queue_id/row_queue_id.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::fmt::Display;
 

--- a/springql-core/src/stream_engine/autonomous_executor/task_graph/queue_id/window_queue_id.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_graph/queue_id/window_queue_id.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::fmt::Display;
 

--- a/springql-core/src/stream_engine/autonomous_executor/task_graph/task_id.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_graph/task_id.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::fmt::Display;
 

--- a/springql-core/src/stream_engine/autonomous_executor/test_support.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/test_support.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 #![allow(missing_docs, dead_code)]
 

--- a/springql-core/src/stream_engine/autonomous_executor/test_support/factory.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/test_support/factory.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::sync::Arc;
 

--- a/springql-core/src/stream_engine/autonomous_executor/test_support/fixture.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/test_support/fixture.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::net::IpAddr;
 

--- a/springql-core/src/stream_engine/autonomous_executor/worker.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/worker.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 //! Worker framework.
 

--- a/springql-core/src/stream_engine/autonomous_executor/worker/worker_handle.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/worker/worker_handle.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::{
     sync::{mpsc, Arc, Mutex, MutexGuard},

--- a/springql-core/src/stream_engine/autonomous_executor/worker/worker_thread.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/worker/worker_thread.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::{
     sync::{mpsc, Arc},

--- a/springql-core/src/stream_engine/command.rs
+++ b/springql-core/src/stream_engine/command.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use self::alter_pipeline_command::AlterPipelineCommand;
 

--- a/springql-core/src/stream_engine/command/alter_pipeline_command.rs
+++ b/springql-core/src/stream_engine/command/alter_pipeline_command.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::pipeline::{
     pump_model::PumpModel, sink_writer_model::SinkWriterModel,

--- a/springql-core/src/stream_engine/command/insert_plan.rs
+++ b/springql-core/src/stream_engine/command/insert_plan.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use serde::{Deserialize, Serialize};
 

--- a/springql-core/src/stream_engine/command/query_plan.rs
+++ b/springql-core/src/stream_engine/command/query_plan.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(crate) mod query_plan_operation;
 

--- a/springql-core/src/stream_engine/command/query_plan/child_direction.rs
+++ b/springql-core/src/stream_engine/command/query_plan/child_direction.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use serde::{Deserialize, Serialize};
 

--- a/springql-core/src/stream_engine/command/query_plan/query_plan_operation.rs
+++ b/springql-core/src/stream_engine/command/query_plan/query_plan_operation.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::{
     expr_resolver::expr_label::{AggrExprLabel, ValueExprLabel},

--- a/springql-core/src/stream_engine/in_memory_queue_repository.rs
+++ b/springql-core/src/stream_engine/in_memory_queue_repository.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 mod in_memory_queue;
 

--- a/springql-core/src/stream_engine/in_memory_queue_repository/in_memory_queue.rs
+++ b/springql-core/src/stream_engine/in_memory_queue_repository/in_memory_queue.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::{
     collections::VecDeque,

--- a/springql-core/src/stream_engine/sql_executor.rs
+++ b/springql-core/src/stream_engine/sql_executor.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::sync::Arc;
 

--- a/springql-core/src/stream_engine/time.rs
+++ b/springql-core/src/stream_engine/time.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(crate) mod duration;
 pub(crate) mod timestamp;

--- a/springql-core/src/stream_engine/time/duration.rs
+++ b/springql-core/src/stream_engine/time/duration.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(crate) mod event_duration;
 pub(crate) mod wall_clock_duration;

--- a/springql-core/src/stream_engine/time/duration/event_duration.rs
+++ b/springql-core/src/stream_engine/time/duration/event_duration.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::{
     fmt::Display,

--- a/springql-core/src/stream_engine/time/duration/wall_clock_duration.rs
+++ b/springql-core/src/stream_engine/time/duration/wall_clock_duration.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub(in crate::stream_engine) mod wall_clock_stopwatch;
 

--- a/springql-core/src/stream_engine/time/duration/wall_clock_duration/wall_clock_stopwatch.rs
+++ b/springql-core/src/stream_engine/time/duration/wall_clock_duration/wall_clock_stopwatch.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use crate::stream_engine::time::{
     duration::SpringDuration,

--- a/springql-core/src/stream_engine/time/timestamp.rs
+++ b/springql-core/src/stream_engine/time/timestamp.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 //! Timestamp.
 

--- a/springql-core/src/stream_engine/time/timestamp/system_timestamp.rs
+++ b/springql-core/src/stream_engine/time/timestamp/system_timestamp.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use super::Timestamp;
 use serde::{Deserialize, Serialize};

--- a/springql-core/tests/e2e_low_level_rs.rs
+++ b/springql-core/tests/e2e_low_level_rs.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 mod test_support;
 

--- a/springql-core/tests/e2e_sampling.rs
+++ b/springql-core/tests/e2e_sampling.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 mod test_support;
 

--- a/springql-core/tests/feat_error.rs
+++ b/springql-core/tests/feat_error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use springql_core::error::SpringError;
 

--- a/springql-core/tests/feat_join.rs
+++ b/springql-core/tests/feat_join.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 mod test_support;
 

--- a/springql-core/tests/feat_logical_ops.rs
+++ b/springql-core/tests/feat_logical_ops.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 mod test_support;
 

--- a/springql-core/tests/feat_numerical_ops.rs
+++ b/springql-core/tests/feat_numerical_ops.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 mod test_support;
 

--- a/springql-core/tests/feat_performance_metrics_report.rs
+++ b/springql-core/tests/feat_performance_metrics_report.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 mod test_support;
 

--- a/springql-core/tests/feat_purger.rs
+++ b/springql-core/tests/feat_purger.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 mod test_support;
 

--- a/springql-core/tests/feat_spring_open_twice.rs
+++ b/springql-core/tests/feat_spring_open_twice.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use springql_core::low_level_rs::{spring_config_default, spring_open};
 

--- a/springql-core/tests/feat_timestamp_ops.rs
+++ b/springql-core/tests/feat_timestamp_ops.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 mod test_support;
 

--- a/springql-core/tests/feat_worker_config.rs
+++ b/springql-core/tests/feat_worker_config.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 mod test_support;
 

--- a/springql-core/tests/test_support/mod.rs
+++ b/springql-core/tests/test_support/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::time::Duration;
 

--- a/test-logger/src/lib.rs
+++ b/test-logger/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::sync::Once;
 

--- a/test-web-console-mock/src/builder.rs
+++ b/test-web-console-mock/src/builder.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::sync::Arc;
 

--- a/test-web-console-mock/src/lib.rs
+++ b/test-web-console-mock/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 pub mod builder;
 pub mod request_body;

--- a/test-web-console-mock/src/request_body.rs
+++ b/test-web-console-mock/src/request_body.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use serde_derive::Deserialize;
 

--- a/test-web-console-mock/src/request_handler.rs
+++ b/test-web-console-mock/src/request_handler.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 TOYOTA MOTOR CORPORATION. Licensed under MIT OR Apache-2.0.
+// This file is part of https://github.com/SpringQL/SpringQL which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::sync::Arc;
 


### PR DESCRIPTION
Fixes: #75 