### PR TITLE
fix: panic by upstream not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog][Keep a Changelog] and this project adh
 
 ## [Unreleased]
 
+## [v0.4.1]
+
+### Fixed
+
+- Potential panic soon after a task graph has been changed by DDL ([#86](https://github.com/SpringQL/SpringQL/pull/86))
+
 ## [v0.4.0]
 
 ### Changed
@@ -71,8 +77,9 @@ The format is based on [Keep a Changelog][Keep a Changelog] and this project adh
 [Semantic Versioning]: https://semver.org/
 
 <!-- Versions -->
-[Unreleased]: https://github.com/SpringQL/SpringQL/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/SpringQL/SpringQL/compare/v0.4.1...HEAD
 [Released]: https://github.com/SpringQL/SpringQL/releases
+[v0.4.1]: https://github.com/SpringQL/SpringQL/compare/v0.4.0...v0.4.1
 [v0.4.0]: https://github.com/SpringQL/SpringQL/compare/v0.3.3...v0.4.0
 [v0.3.3]: https://github.com/SpringQL/SpringQL/compare/v0.3.2...v0.3.3
 [v0.3.2]: https://github.com/SpringQL/SpringQL/compare/v0.3.1...v0.3.2

--- a/springql-core/src/stream_engine/autonomous_executor/task/pump_task/pump_subtask/query_subtask/collect_subtask.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/pump_task/pump_subtask/query_subtask/collect_subtask.rs
@@ -39,10 +39,11 @@ impl CollectSubtask {
         let pipeline_derivatives = context.pipeline_derivatives();
         let task_graph = pipeline_derivatives.task_graph();
 
-        let queue_id = task_graph.input_queue(&pump_task_id, &self.upstream);
-        match queue_id {
-            QueueId::Row(queue_id) => self.collect_from_row_queue(queue_id, repos),
-            QueueId::Window(queue_id) => self.collect_from_window_queue(queue_id, repos),
+        let opt_queue_id = task_graph.input_queue(&pump_task_id, &self.upstream);
+        match opt_queue_id {
+            Some(QueueId::Row(queue_id)) => self.collect_from_row_queue(queue_id, repos),
+            Some(QueueId::Window(queue_id)) => self.collect_from_window_queue(queue_id, repos),
+            None => None,
         }
     }
 

--- a/springql-core/src/stream_engine/autonomous_executor/task/sink_task.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/sink_task.rs
@@ -46,18 +46,21 @@ impl SinkTask {
 
         let repos = context.repos();
 
-        let queue_id = context
+        let opt_in_queue_id = context
             .pipeline_derivatives()
             .task_graph()
             .input_queue(&context.task(), &self.upstream);
 
-        let in_queues_metrics =
-            if let Some((row, in_queue_metrics)) = self.use_row_from(queue_id, repos) {
+        let in_queues_metrics = if let Some(in_queue_id) = opt_in_queue_id {
+            if let Some((row, in_queue_metrics)) = self.use_row_from(in_queue_id, repos) {
                 self.emit(row, context)?;
                 vec![in_queue_metrics]
             } else {
                 vec![]
-            };
+            }
+        } else {
+            vec![]
+        };
 
         let execution_time = stopwatch.stop();
 

--- a/springql-core/src/stream_engine/autonomous_executor/task_graph.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_graph.rs
@@ -265,6 +265,8 @@ impl From<&Pipeline> for TaskGraph {
                 Edge::Source(_) => {} // no queue is created for source task
             };
         }
+        log::error!("{:#?}", task_graph);
+
         task_graph
     }
 }

--- a/springql-core/src/stream_engine/autonomous_executor/task_graph.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_graph.rs
@@ -31,7 +31,7 @@ use self::{
 #[derive(Clone, Debug, new)]
 pub(super) struct QueueIdWithUpstream {
     queue_id: QueueId,
-    upstream: StreamName,
+    upstream: StreamName, // FIXME avoid mixing pipeline and task graph objects. It leads to [#86](https://github.com/SpringQL/SpringQL/pull/86)
 }
 
 #[derive(Debug)]

--- a/springql-core/src/stream_engine/autonomous_executor/task_graph.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_graph.rs
@@ -95,10 +95,11 @@ impl TaskGraph {
             .collect()
     }
 
-    /// # Panics
+    /// # Returns
     ///
-    /// if `task_id` does not have incoming edge (queue) from `upstream`.
-    pub(super) fn input_queue(&self, task_id: &TaskId, upstream: &StreamName) -> QueueId {
+    /// `None` if `task_id` does not have incoming edge (queue) from `upstream`.
+    /// This may happen when `task_id` and `upstream` come from different versions of pipeline.
+    pub(super) fn input_queue(&self, task_id: &TaskId, upstream: &StreamName) -> Option<QueueId> {
         let i = self.find_node(task_id);
         self.g
             .edges_directed(i, petgraph::EdgeDirection::Incoming)
@@ -107,12 +108,6 @@ impl TaskGraph {
                 let queue_id_with_upstream = e.weight();
                 (&queue_id_with_upstream.upstream == upstream)
                     .then(|| queue_id_with_upstream.queue_id.clone())
-            })
-            .unwrap_or_else(|| {
-                panic!(
-                    "task id {:?} does not have upstream {}: task graph - {:#?}",
-                    task_id, upstream, self
-                )
             })
     }
 

--- a/springql-core/src/stream_engine/autonomous_executor/task_graph.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_graph.rs
@@ -265,8 +265,6 @@ impl From<&Pipeline> for TaskGraph {
                 Edge::Source(_) => {} // no queue is created for source task
             };
         }
-        log::error!("{:#?}", task_graph);
-
         task_graph
     }
 }

--- a/springql-core/src/stream_engine/autonomous_executor/task_graph.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_graph.rs
@@ -108,7 +108,12 @@ impl TaskGraph {
                 (&queue_id_with_upstream.upstream == upstream)
                     .then(|| queue_id_with_upstream.queue_id.clone())
             })
-            .unwrap_or_else(|| panic!("task id {:?} does not have upstream {}", task_id, upstream))
+            .unwrap_or_else(|| {
+                panic!(
+                    "task id {:?} does not have upstream {}: pipeline graph - {:#?}",
+                    task_id, upstream, self.g
+                )
+            })
     }
 
     pub(super) fn downstream_tasks(&self, task_id: &TaskId) -> Vec<TaskId> {

--- a/springql-core/src/stream_engine/autonomous_executor/task_graph.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_graph.rs
@@ -111,7 +111,7 @@ impl TaskGraph {
             .unwrap_or_else(|| {
                 panic!(
                     "task id {:?} does not have upstream {}: task graph - {:#?}",
-                    task_id, upstream, self.g
+                    task_id, upstream, self
                 )
             })
     }

--- a/springql-core/src/stream_engine/autonomous_executor/task_graph.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_graph.rs
@@ -110,7 +110,7 @@ impl TaskGraph {
             })
             .unwrap_or_else(|| {
                 panic!(
-                    "task id {:?} does not have upstream {}: pipeline graph - {:#?}",
+                    "task id {:?} does not have upstream {}: task graph - {:#?}",
                     task_id, upstream, self.g
                 )
             })


### PR DESCRIPTION
Fixes: #80 

[input_queue()](https://github.com/SpringQL/SpringQL/pull/86/files#diff-846b45cd48368aaf0b3bfe1c01667a4f592f55ee4f35cd0f0bf1519e9cdf24cbR102) takes `task_id` and `upstream` parameters.

These parameters come from different threads:

- `task_id` is from GenericWorkerThread
- `upstream` is from main thread (when creating `CollectSubtask`)

These threads may observe different PipelineVersion.