### PR TITLE
Coverage with grcov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_SECRET }}
-          files: ./lcov.info
+          files: ./target/lcov.info
 
   slack-notify:
     if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Install cargo-make
         env:
           BASE_URL: https://github.com/sagiegurari/cargo-make/releases/download
-          VERSION: 0.35.2
+          VERSION: 0.35.10
         run: |
           if [ "${{ matrix.os }}" = "macos-latest" ]; then
             FILE_BASE=cargo-make-v${VERSION}-x86_64-apple-darwin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
               task: lcov
               install-grcov: true
             os: ubuntu-latest
-            rust: nightly
+            rust: stable
           - make:
               task: copyright
               rust-free: true

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,3 +1,8 @@
+extend= [
+  { path = "coverage_grcov.makefile.toml" }
+]
+
+
 [config]
 default_to_workspace = false
 skip_core_tasks = true
@@ -74,18 +79,4 @@ cargo workspaces publish
 ]
 
 [tasks.lcov]
-script = [
-  '''
-#!/usr/bin/env bash -eux
-rm -rf target/debug/deps/${PROJ_NAME}-*
-
-export CARGO_INCREMENTAL=0
-export RUSTFLAGS="-Zinstrument-coverage"
-export LLVM_PROFILE_FILE="${PROJ_NAME}-%p-%m.profraw"
-
-cargo +nightly build --workspace --verbose
-cargo +nightly test --workspace --verbose
-
-grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o lcov.info
-''',
-]
+alias="coverage_grcov"

--- a/coverage_grcov.makefile.toml
+++ b/coverage_grcov.makefile.toml
@@ -1,0 +1,129 @@
+# coverage_grcov.makefile.toml
+#
+#  comes from https://github.com/kazuk/cargo-make-coverage-grcov
+#
+# The Unlicense
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# For more information, please refer to <https://unlicense.org>
+#
+
+[env]
+COVERAGE_TARGET_DIRECTORY="${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target/cover"
+COVERAGE_BINARIES="${COVERAGE_TARGET_DIRECTORY}/debug/deps"
+COVERAGE_PROF_OUTPUT="${COVERAGE_BINARIES}/profraw"
+COVERAGE_OUTPUT_LCOV="${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target/lcov.info"
+
+[tasks.coverage_grcov_build_nightly]
+condition = { rust_version = { max = "1.59.9" } }
+private=true
+toolchain = "nightly"
+command = "cargo"
+args = ["build"]
+
+  [tasks.coverage_grcov_build_nightly.env]
+  "CARGO_BUILD_TARGET_DIR"="${COVERAGE_TARGET_DIRECTORY}"
+  "RUSTFLAGS"= "-Cinstrument-coverage -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off"
+  "RUSTDOCFLAGS"="-Cpanic=abort"
+
+[tasks.coverage_grcov_build_stable]
+condition = { rust_version = { min = "1.60.0" } }
+private=true
+command = "cargo"
+args = ["build"]
+
+  [tasks.coverage_grcov_build_stable.env]
+  "CARGO_BUILD_TARGET_DIR"="${COVERAGE_TARGET_DIRECTORY}"
+  "RUSTFLAGS"= "-Cinstrument-coverage -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off"
+  "RUSTDOCFLAGS"="-Cpanic=abort"
+
+
+[tasks.coverage_grcov_run_test_nightly]
+condition = { rust_version = { max = "1.59.9" } }
+private=true
+toolchain="nightly"
+command = "cargo"
+args = ["test", "--verbose"]
+
+  [tasks.coverage_grcov_run_test_nightly.env]
+  "CARGO_BUILD_TARGET_DIR"="${COVERAGE_TARGET_DIRECTORY}"
+  "LLVM_PROFILE_FILE"="${COVERAGE_PROF_OUTPUT}/coverage-%p-%m.profraw"
+
+[tasks.coverage_grcov_run_test_stable]
+condition = { rust_version = { min = "1.60.0" } }
+private=true
+command = "cargo"
+args = ["test", "--verbose"]
+
+  [tasks.coverage_grcov_run_test_stable.env]
+  "CARGO_BUILD_TARGET_DIR"="${COVERAGE_TARGET_DIRECTORY}"
+  "LLVM_PROFILE_FILE"="${COVERAGE_PROF_OUTPUT}/coverage-%p-%m.profraw"
+
+
+[tasks.coverage_grcov_prepare_outdir]
+private=true
+workspace=true
+script='''
+#!/usr/bin/env bash
+set -eux
+
+rm -rf ${COVERAGE_PROF_OUTPUT}
+mkdir -p ${COVERAGE_PROF_OUTPUT}
+'''
+
+[tasks.install_grcov]
+workspace=true
+install_crate= {crate_name="grcov"}
+
+[tasks.coverage_grcov_nightly]
+condition = { rust_version = { max = "1.59.9" } }
+workspace=true
+env = {"RUSTUP_TOOLCHAIN"="nightly"}
+script = '''
+#!/usr/bin/env bash
+set -eux
+
+grcov ${COVERAGE_PROF_OUTPUT} \
+  -b ${COVERAGE_BINARIES} -s ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY} \
+  -t lcov --llvm --branch --ignore-not-existing --ignore "/*" -o ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target/lcov.info
+'''
+dependencies=["install_grcov","coverage_grcov_build_nightly", "coverage_grcov_prepare_outdir", "coverage_grcov_run_test_nightly"]
+
+[tasks.coverage_grcov_stable]
+condition = { rust_version = { min = "1.60.0" } }
+workspace=true
+script = '''
+#!/usr/bin/env bash
+set -eux
+
+grcov ${COVERAGE_PROF_OUTPUT} \
+  -b ${COVERAGE_BINARIES} -s ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY} \
+  -t lcov --llvm --branch --ignore-not-existing --ignore "/*" -o ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target/lcov.info
+'''
+dependencies=["install_grcov","coverage_grcov_build_stable", "coverage_grcov_prepare_outdir", "coverage_grcov_run_test_stable"]
+
+[tasks.coverage_grcov]
+dependencies=["coverage_grcov_nightly","coverage_grcov_stable"]
+


### PR DESCRIPTION
Close #69 

  add coverage_grcov.makefile.toml.
  make lcov task to alias coverage_grcov.

  change upload codecov coverage data from `./lcov.info` to `./target/lcov.info`

---
@laysakura added: also fixes: #89 