### PR TITLE
docs: adds `### For developers` section in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][Keep a Changelog] and this project adheres to [Semantic Versioning][Semantic Versioning].
 
+We originally added `### For developers` sections in order to separate changes for end-users and developers.
+All other sections are for end-users.
+
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 


### PR DESCRIPTION
## Issue number and link

none

<!--- For bugfix, you must link to at least an issue to show clear way to reproduce the bug. -->

<!--- For new feature without any related issues, include your motivation in the next section -->

## Describe your changes

Sometimes, we want to remark changes for our contributors in CHANGELOG.

Also, in "keep a changelog" format, we sometimes get confused whether `### Fixed` should include some internal changes like refactoring.

I noted at the top of CHANGELOG that only the new `### For developers` section is for developers, and others are for end-users.

## Checklist before requesting a review

- [x] I follow the [Semantic Pull Requests](https://github.com/zeke/semantic-pull-requests) rules (bugfix/feature)
- [ ] I specified links to related issues (must: bugfix, want: feature)
- [x] I have performed a self-review of my code (bugfix/feature)
- [ ] I have added thorough tests (bugfix/feature)
- [ ] I have edited `## [Unreleased]` section in `CHANGELOG.md` following [keep a changelog](https://keepachangelog.com/en/1.0.0/) syntax (bugfix/feature)
- [ ] I {made/will make} a related pull request for [documentation repo](https://github.com/SpringQL/SpringQL.github.io) (feature)
