### PR TITLE
chore: remove intra-doc link in non-public entities

### DIFF
--- a/springql-core/src/pipeline.rs
+++ b/springql-core/src/pipeline.rs
@@ -92,11 +92,11 @@ pub fn spring_open(config: &SpringConfig) -> Result<SpringPipeline> {
 ///
 /// # Failure
 ///
-/// - [SpringError::Sql](crate::api::error::SpringError::Sql) when:
+/// - `SpringError::Sql` when:
 ///   - Invalid SQL syntax.
 ///   - Refers to undefined objects (streams, pumps, etc)
 ///   - Other semantic errors.
-/// - [SpringError::InvalidOption](crate::api::error::SpringError::Sql) when:
+/// - `SpringError::InvalidOption` when:
 ///   - `OPTIONS` in `CREATE` statement includes invalid key or value.
 pub fn spring_command(pipeline: &SpringPipeline, sql: &str) -> Result<()> {
     let mut engine = pipeline.engine.get()?;
@@ -118,7 +118,7 @@ pub fn spring_command(pipeline: &SpringPipeline, sql: &str) -> Result<()> {
 ///
 /// # Failure
 ///
-/// - [SpringError::Unavailable](crate::api::error::SpringError::Unavailable) when:
+/// - `SpringError::Unavailable` when:
 ///   - queue named `queue` does not exist.
 pub fn spring_pop(pipeline: &SpringPipeline, queue: &str) -> Result<SpringRow> {
     const SLEEP_MSECS: u64 = 10;
@@ -145,7 +145,7 @@ pub fn spring_pop(pipeline: &SpringPipeline, queue: &str) -> Result<SpringRow> {
 ///
 /// # Failure
 ///
-/// - [SpringError::Unavailable](crate::api::error::SpringError::Unavailable) when:
+/// - `SpringError::Unavailable` when:
 ///   - queue named `queue` does not exist.
 pub fn spring_pop_non_blocking(
     pipeline: &SpringPipeline,
@@ -182,7 +182,7 @@ impl Pipeline {
 
     /// # Failure
     ///
-    /// - [SpringError::Sql](crate::error::SpringError::Sql) when:
+    /// - `SpringError::Sql` when:
     ///   - Stream is not registered in pipeline
     pub(super) fn get_stream(&self, stream: &StreamName) -> Result<Arc<StreamModel>> {
         self.graph.get_stream(stream)
@@ -190,7 +190,7 @@ impl Pipeline {
 
     /// # Failure
     ///
-    /// - [SpringError::Sql](crate::error::SpringError::Sql) when:
+    /// - `SpringError::Sql` when:
     ///   - Name of pump is already used in the same pipeline
     ///   - Name of upstream stream is not found in pipeline
     ///   - Name of downstream stream is not found in pipeline
@@ -202,7 +202,7 @@ impl Pipeline {
 
     /// # Failure
     ///
-    /// - [SpringError::Sql](crate::error::SpringError::Sql) when:
+    /// - `SpringError::Sql` when:
     ///   - Name of stream is already used in the same pipeline
     pub(super) fn add_stream(&mut self, stream: Arc<StreamModel>) -> Result<()> {
         self.update_version();
@@ -234,7 +234,7 @@ impl Pipeline {
 
     /// # Failure
     ///
-    /// - [SpringError::Sql](crate::error::SpringError::Sql) when:
+    /// - `SpringError::Sql` when:
     ///   - Name is already used in the same pipeline
     fn register_name(&mut self, name: &str) -> Result<()> {
         if !self.object_names.insert(name.to_string()) {

--- a/springql-core/src/pipeline/option.rs
+++ b/springql-core/src/pipeline/option.rs
@@ -21,7 +21,7 @@ pub(crate) struct Options(HashMap<String, String>);
 impl Options {
     /// # Failure
     ///
-    /// - [SpringError::InvalidOption](crate SpringError::InvalidOption) when:
+    /// - `SpringError::InvalidOption` when:
     ///   - key is not found in this Options.
     pub(crate) fn get<V, F>(&self, key: &str, value_parser: F) -> Result<V>
     where

--- a/springql-core/src/pipeline/pump_model/window_operation_parameter/aggregate.rs
+++ b/springql-core/src/pipeline/pump_model/window_operation_parameter/aggregate.rs
@@ -14,7 +14,7 @@ impl GroupByLabels {
     }
 }
 
-/// TODO [support complex expression with aggregations](https://gh01.base.toyota-tokyo.tech/SpringQL-internal/SpringQL/issues/152)
+/// TODO `support complex expression with aggregations`
 ///
 /// ```sql
 /// SELECT group_by, aggr_expr.func(aggr_expr.aggregated)

--- a/springql-core/src/pipeline/pump_model/window_operation_parameter/join_parameter.rs
+++ b/springql-core/src/pipeline/pump_model/window_operation_parameter/join_parameter.rs
@@ -4,7 +4,7 @@ use crate::{
     expr_resolver::expr_label::ValueExprLabel, pipeline::field::field_name::ColumnReference,
 };
 
-/// TODO [support complex expression with aggregations](https://gh01.base.toyota-tokyo.tech/SpringQL-internal/SpringQL/issues/152)
+/// TODO `support complex expression with aggregations`
 ///
 /// ```sql
 /// SELECT s.c1, t.c2

--- a/springql-core/src/pipeline/stream_model/stream_shape.rs
+++ b/springql-core/src/pipeline/stream_model/stream_shape.rs
@@ -17,7 +17,7 @@ pub(crate) struct StreamShape {
 impl StreamShape {
     /// # Failure
     ///
-    /// - [SpringError::Sql](crate::error::SpringError::Sql) when:
+    /// - `SpringError::Sql` when:
     ///   - ROWTIME column in `cols` is not a `TIMESTAMP NOT NULL` type.
     ///   - 2 or more column have ROWTIME constraints
     pub(in crate) fn new(cols: Vec<ColumnDefinition>) -> Result<Self> {

--- a/springql-core/src/sql_processor.rs
+++ b/springql-core/src/sql_processor.rs
@@ -29,7 +29,7 @@ pub(crate) struct SqlProcessor(SqlParser);
 impl SqlProcessor {
     /// # Failures
     ///
-    /// - [SpringError::Sql](crate::error::SpringError::Sql) on syntax and semantics error.
+    /// - `SpringError::Sql` on syntax and semantics error.
     pub(crate) fn compile<S: Into<String>>(&self, sql: S, pipeline: &Pipeline) -> Result<Command> {
         let command = match self.0.parse(sql)? {
             ParseSuccess::CreateSourceStream(source_stream_model) => {

--- a/springql-core/src/sql_processor/sql_parser/pest_parser_impl/helper.rs
+++ b/springql-core/src/sql_processor/sql_parser/pest_parser_impl/helper.rs
@@ -34,7 +34,7 @@ pub(super) struct FnParseParams<'a> {
 ///
 /// # Failures
 ///
-/// - [SpringError::Sql](crate::error::SpringError::Sql) when:
+/// - `SpringError::Sql` when:
 ///   - When no child term left.
 ///   - When the next child term does not match $child_term.
 ///   - Raises Err from `child_parser` as-is.

--- a/springql-core/src/stream_engine.rs
+++ b/springql-core/src/stream_engine.rs
@@ -43,7 +43,7 @@ impl EngineMutex {
 
     /// # Failure
     ///
-    /// - [SpringError::ThreadPoisoned](crate::error::SpringError::ThreadPoisoned)
+    /// - `SpringError::ThreadPoisoned`
     pub(crate) fn get(&self) -> Result<MutexGuard<'_, StreamEngine>> {
         self.0
             .lock()
@@ -93,7 +93,7 @@ impl StreamEngine {
     ///
     /// # Failure
     ///
-    /// - [SpringError::Unavailable](crate::error::SpringError::Unavailable) when:
+    /// - `SpringError::Unavailable` when:
     ///   - queue named `queue_name` does not exist.
     pub(crate) fn pop_in_memory_queue_non_blocking(
         &mut self,

--- a/springql-core/src/stream_engine/autonomous_executor/performance_metrics.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/performance_metrics.rs
@@ -33,8 +33,8 @@ use crate::{
 
 /// Performance metrics of task execution. It has the same lifetime as a TaskGraph (i.e. a Pipeline).
 ///
-/// It is monitored by [PerformanceMonitorWorker](crate::stream_processor::autonomous_executor::worker::performance_monitor_worker::PerformanceMonitoRworker),
-/// and it is updated by [TaskExecutor](crate::stream_processor::autonomous_executor::task_executor::TaskExecutor).
+/// It is monitored by `PerformanceMonitorWorker`,
+/// and it is updated by `TaskExecutor`.
 ///
 /// `PerformanceMonitorWorker` does not frequently read from `RwLock<*Metrics>`, and schedulers in `TaskExecutor` are not expected to
 /// execute consequent tasks (sharing the same queue as input or output) by different workers at the same time.

--- a/springql-core/src/stream_engine/autonomous_executor/performance_metrics/performance_metrics_summary.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/performance_metrics/performance_metrics_summary.rs
@@ -4,9 +4,9 @@ use std::fmt::Display;
 
 use crate::stream_engine::autonomous_executor::performance_metrics::PerformanceMetrics;
 
-/// Summary of [PerformanceMetrics](super::PerformanceMetrics).
+/// Summary of `PerformanceMetrics`.
 ///
-/// From this summary, [TaskExecutor](crate::stream_processor::autonomous_executor::task_executor::TaskExecutor):
+/// From this summary, `TaskExecutor`:
 /// - transits memory state diagram
 /// - changes task scheduler
 /// - launches purger

--- a/springql-core/src/stream_engine/autonomous_executor/performance_monitor_worker.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/performance_monitor_worker.rs
@@ -20,8 +20,8 @@ use crate::{
 
 /// Dedicated thread to:
 ///
-/// 1. Monitor performance of task graphs via [PerformanceMetrics](crate::stream_engine::autonomous_executor::performance_monitor::PerformanceMetrics).
-/// 2. Report the performance to [AutonomousExecutor](crate::stream_processor::autonomous_executor::AutonomousExecutor) and web-console.
+/// 1. Monitor performance of task graphs via `PerformanceMetrics`.
+/// 2. Report the performance to `AutonomousExecutor` and web-console.
 #[derive(Debug)]
 pub(in crate::stream_engine::autonomous_executor) struct PerformanceMonitorWorker {
     _handle: WorkerHandle,

--- a/springql-core/src/stream_engine/autonomous_executor/pipeline_derivatives.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/pipeline_derivatives.rs
@@ -53,7 +53,7 @@ impl PipelineDerivatives {
 
     /// # Failure
     ///
-    /// - [SpringError::Sql](crate::error::SpringError::Sql) when:
+    /// - `SpringError::Sql` when:
     ///   - TaskId is not found in task graph.
     pub(in crate::stream_engine::autonomous_executor) fn get_task(
         &self,

--- a/springql-core/src/stream_engine/autonomous_executor/pipeline_derivatives/task_repository.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/pipeline_derivatives/task_repository.rs
@@ -21,7 +21,7 @@ pub(in crate::stream_engine::autonomous_executor) struct TaskRepository {
 impl TaskRepository {
     /// # Failure
     ///
-    /// - [SpringError::Sql](crate::error::SpringError::Sql) when:
+    /// - `SpringError::Sql` when:
     ///   - TaskId is not found in task repo.
     pub(super) fn get(&self, task_id: &TaskId) -> Result<Arc<Task>> {
         self.repo

--- a/springql-core/src/stream_engine/autonomous_executor/row.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row.rs
@@ -70,7 +70,7 @@ impl Row {
 
     /// # Failure
     ///
-    /// - [SpringError::Sql](crate::error::SpringError::Sql) when:
+    /// - `SpringError::Sql` when:
     ///   - Column index out of range
     pub(in crate::stream_engine::autonomous_executor) fn get_by_index(
         &self,

--- a/springql-core/src/stream_engine/autonomous_executor/row/column/stream_column.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/column/stream_column.rs
@@ -38,7 +38,7 @@ impl StreamColumns {
     ///
     /// # Failure
     ///
-    /// - [SpringError::Sql](crate::error::SpringError::Sql) when:
+    /// - `SpringError::Sql` when:
     ///   - `column_values` lacks any of `stream.columns()`.
     ///   - Type mismatch (and failed to convert type) with `stream_shape` and `column_values`.
     pub(in crate::stream_engine::autonomous_executor) fn new(
@@ -81,7 +81,7 @@ impl StreamColumns {
 
     /// # Failure
     ///
-    /// - [SpringError::Sql](crate::error::SpringError::Sql) when:
+    /// - `SpringError::Sql` when:
     ///   - Column index out of range
     pub(in crate::stream_engine::autonomous_executor) fn get_by_index(
         &self,
@@ -95,7 +95,7 @@ impl StreamColumns {
 
     /// # Failure
     ///
-    /// - [SpringError::Sql](crate::error::SpringError::Sql) when:
+    /// - `SpringError::Sql` when:
     ///   - No column named `column_name` is found from this stream.
     pub(in crate::stream_engine::autonomous_executor) fn get_by_column_name(
         &self,

--- a/springql-core/src/stream_engine/autonomous_executor/row/column_values.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/column_values.rs
@@ -19,7 +19,7 @@ pub(in crate::stream_engine::autonomous_executor) struct ColumnValues(
 impl ColumnValues {
     /// # Failure
     ///
-    /// - [SpringError::Sql](crate::error::SpringError::Sql) when:
+    /// - `SpringError::Sql` when:
     ///   - `k` is already inserted.
     pub(in crate::stream_engine::autonomous_executor) fn insert(
         &mut self,
@@ -38,7 +38,7 @@ impl ColumnValues {
 
     /// # Failure
     ///
-    /// - [SpringError::Sql](crate::error::SpringError::Sql) when:
+    /// - `SpringError::Sql` when:
     ///   - `k` does not included.
     pub(in crate::stream_engine::autonomous_executor) fn remove(
         &mut self,

--- a/springql-core/src/stream_engine/autonomous_executor/row/foreign_row/format/json.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/foreign_row/format/json.rs
@@ -28,7 +28,7 @@ impl From<JsonObject> for serde_json::Value {
 impl JsonObject {
     /// # Failure
     ///
-    /// - [SpringError::InvalidFormat](crate::error::SpringError::InvalidFormat) when:
+    /// - `SpringError::InvalidFormat` when:
     ///   - Internal JSON cannot be mapped to SQL type (nested, for example).
     ///
     /// # TODO

--- a/springql-core/src/stream_engine/autonomous_executor/row/foreign_row/sink_row.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/foreign_row/sink_row.rs
@@ -35,7 +35,7 @@ impl From<Row> for SinkRow {
 impl SinkRow {
     /// # Failure
     ///
-    /// - [SpringError::Sql](crate::error::SpringError::Sql) when:
+    /// - `SpringError::Sql` when:
     ///   - Column index out of range
     pub(crate) fn get_by_index(&self, i_col: usize) -> Result<&SqlValue> {
         self.0.get_by_index(i_col)

--- a/springql-core/src/stream_engine/autonomous_executor/row/foreign_row/source_row.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/foreign_row/source_row.rs
@@ -23,7 +23,7 @@ impl SourceRow {
 
     /// # Failure
     ///
-    /// - [SpringError::InvalidFormat](crate::error::SpringError::InvalidFormat) when:
+    /// - `SpringError::InvalidFormat` when:
     ///   - This input row cannot be converted into row.
     pub(in crate::stream_engine::autonomous_executor) fn into_row(
         self,

--- a/springql-core/src/stream_engine/autonomous_executor/row/value/sql_convertible.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/value/sql_convertible.rs
@@ -22,7 +22,7 @@ use crate::stream_engine::autonomous_executor::row::value::sql_value::nn_sql_val
 pub trait SpringValue: Sized {
     /// # Failures
     ///
-    /// - [SpringError::Sql](crate::api::error::SpringError::Sql) when:
+    /// - `SpringError::Sql` when:
     ///   - the type implementing SqlConvertible is not convertible from i16
     fn try_from_i16(_: &i16) -> Result<Self> {
         Self::default_err("i16")
@@ -30,7 +30,7 @@ pub trait SpringValue: Sized {
 
     /// # Failures
     ///
-    /// - [SpringError::Sql](crate::api::error::SpringError::Sql) when:
+    /// - `SpringError::Sql` when:
     ///   - the type implementing SqlConvertible is not convertible from i32
     fn try_from_i32(_: &i32) -> Result<Self> {
         Self::default_err("i32")
@@ -38,7 +38,7 @@ pub trait SpringValue: Sized {
 
     /// # Failures
     ///
-    /// - [SpringError::Sql](crate::api::error::SpringError::Sql) when:
+    /// - `SpringError::Sql` when:
     ///   - the type implementing SqlConvertible is not convertible from i64
     fn try_from_i64(_: &i64) -> Result<Self> {
         Self::default_err("i64")
@@ -46,7 +46,7 @@ pub trait SpringValue: Sized {
 
     /// # Failures
     ///
-    /// - [SpringError::Sql](crate::api::error::SpringError::Sql) when:
+    /// - `SpringError::Sql` when:
     ///   - the type implementing SqlConvertible is not convertible from f32
     fn try_from_f32(_: &f32) -> Result<Self> {
         Self::default_err("f32")
@@ -54,7 +54,7 @@ pub trait SpringValue: Sized {
 
     /// # Failures
     ///
-    /// - [SpringError::Sql](crate::api::error::SpringError::Sql) when:
+    /// - `SpringError::Sql` when:
     ///   - the type implementing SqlConvertible is not convertible from String
     fn try_from_string(_: &str) -> Result<Self> {
         Self::default_err("String")
@@ -62,7 +62,7 @@ pub trait SpringValue: Sized {
 
     /// # Failures
     ///
-    /// - [SpringError::Sql](crate::api::error::SpringError::Sql) when:
+    /// - `SpringError::Sql` when:
     ///   - the type implementing SqlConvertible is not convertible from bool
     fn try_from_bool(_: &bool) -> Result<Self> {
         Self::default_err("bool")
@@ -70,7 +70,7 @@ pub trait SpringValue: Sized {
 
     /// # Failures
     ///
-    /// - [SpringError::Sql](crate::api::error::SpringError::Sql) when:
+    /// - `SpringError::Sql` when:
     ///   - the type implementing SqlConvertible is not convertible from Timestamp
     fn try_from_timestamp(_: &SpringTimestamp) -> Result<Self> {
         Self::default_err("Timestamp")
@@ -78,7 +78,7 @@ pub trait SpringValue: Sized {
 
     /// # Failures
     ///
-    /// - [SpringError::Sql](crate::api::error::SpringError::Sql) when:
+    /// - `SpringError::Sql` when:
     ///   - the type implementing SqlConvertible is not convertible from EventDuration
     fn try_from_duration(_: &SpringEventDuration) -> Result<Self> {
         Self::default_err("EventDuration")

--- a/springql-core/src/stream_engine/autonomous_executor/row/value/sql_value.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/value/sql_value.rs
@@ -34,8 +34,8 @@ use crate::{
 /// # Comparing SqlValues
 ///
 /// An SqlValue implements is NULL or NOT NULL.
-/// NOT NULL value has its SQL type in [SqlType](crate::SqlType).
-/// SqlType forms hierarchical structure and if its comparable top-level variant (e.g. [SqlType::NumericComparable](crate::SqlType::NumericComparable)) are the same among two values,
+/// NOT NULL value has its SQL type in `SqlType`.
+/// SqlType forms hierarchical structure and if its comparable top-level variant (e.g. `SqlType::NumericComparable`) are the same among two values,
 /// these two are **comparable**, meaning equality comparison to them is valid.
 /// Also, ordered comparison is valid for values within some top-level variant of Constant.
 /// Such variants and values within one are called **ordered**.
@@ -43,7 +43,7 @@ use crate::{
 ///
 /// ## Failures on comparison
 ///
-/// Comparing non-**comparable** values and ordered comparison to non-**ordered** values cause [SqlState::DataExceptionIllegalComparison](crate::SqlState::DataExceptionIllegalComparison).
+/// Comparing non-**comparable** values and ordered comparison to non-**ordered** values cause `SqlState::DataExceptionIllegalComparison`.
 ///
 /// ## Comparison with NULL
 ///
@@ -57,11 +57,11 @@ use crate::{
 /// Hashed values are sometimes used in query execution (e.g. hash-join, hash-aggregation).
 /// SqlValue implements `Hash` but does not `Eq` so SqlValue cannot be used as hash key of `HashMap` and `HashSet`.
 ///
-/// Use [SqlValueHashKey](self::sql_value_hash_key::SqlValueHashKey) for that purpose.
+/// Use `SqlValueHashKey` for that purpose.
 ///
 /// # Examples
 ///
-/// See: [test_sql_value_example()](self::tests::test_sql_value_example).
+/// See: `test_sql_value_example()`.
 #[derive(Clone, Debug)]
 pub(crate) enum SqlValue {
     /// NULL value.
@@ -113,12 +113,12 @@ impl SqlValue {
     ///
     /// # Failures
     ///
-    /// - [SpringError::Sql](crate::error::SpringError::Sql) when:
-    ///   - `self` and `other` have different top-level variant of [SqlType](crate::SqlType).
+    /// - `SpringError::Sql` when:
+    ///   - `self` and `other` have different top-level variant of `SqlType`.
     ///
     /// # Examples
     ///
-    /// See: [test_sql_compare_example()](self::tests::test_sql_compare_example).
+    /// See: `test_sql_compare_example()`.
     pub fn sql_compare(&self, other: &Self) -> Result<SqlCompareResult> {
         match (self, other) {
             (SqlValue::Null, _) | (_, SqlValue::Null) => Ok(SqlCompareResult::Null),

--- a/springql-core/src/stream_engine/autonomous_executor/row/value/sql_value/nn_sql_value.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/value/sql_value/nn_sql_value.rs
@@ -159,7 +159,7 @@ impl NnSqlValue {
     ///
     /// # Failures
     ///
-    /// - [SpringError::Sql](crate::error::SpringError::Sql) when:
+    /// - `SpringError::Sql` when:
     ///   - Any value of `T` cannot be typed as this SqlValue's SqlType (E.g. `T = i64`, `SqlType = SmallInt`).
     pub fn unpack<T>(&self) -> Result<T>
     where
@@ -199,7 +199,7 @@ impl NnSqlValue {
     ///
     /// # Failures
     ///
-    /// - [SpringError::Sql](crate::error::SpringError::Sql) when:
+    /// - `SpringError::Sql` when:
     ///   - Value cannot be converted to `typ`.
     pub(crate) fn try_convert(&self, typ: &SqlType) -> Result<NnSqlValue> {
         match typ {

--- a/springql-core/src/stream_engine/autonomous_executor/row/value/sql_value/sql_compare_result.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/row/value/sql_value/sql_compare_result.rs
@@ -2,7 +2,7 @@
 
 use std::cmp::Ordering;
 
-/// Comparison result of two [SqlValue](crate::SqlValue)s.
+/// Comparison result of two `SqlValue`s.
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub(crate) enum SqlCompareResult {
     /// v1 = v2

--- a/springql-core/src/stream_engine/autonomous_executor/task/sink_task/sink_writer.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/sink_task/sink_writer.rs
@@ -26,9 +26,9 @@ pub(in crate::stream_engine) trait SinkWriter:
 
     /// # Failure
     ///
-    /// - [SpringError::ForeignSourceTimeout](crate::error::SpringError::ForeignSourceTimeout) when:
+    /// - `SpringError::ForeignSourceTimeout` when:
     ///   - Remote sink does not accept row within timeout.
-    /// - [SpringError::ForeignIo](crate::error::SpringError::ForeignIo) when:
+    /// - `SpringError::ForeignIo` when:
     ///   - Remote sink has failed to parse request.
     ///   - Unknown foreign error.
     fn send_row(&mut self, row: SinkRow) -> Result<()>;

--- a/springql-core/src/stream_engine/autonomous_executor/task/sink_task/sink_writer/sink_writer_repository.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/sink_task/sink_writer/sink_writer_repository.rs
@@ -37,7 +37,7 @@ impl SinkWriterRepository {
     ///
     /// # Failures
     ///
-    /// - [SpringError::ForeignIo](crate::error::SpringError::ForeignIo) when:
+    /// - `SpringError::ForeignIo` when:
     ///   - failed to start subtask.
     pub(in crate::stream_engine::autonomous_executor) fn register(
         &self,

--- a/springql-core/src/stream_engine/autonomous_executor/task/source_task/source_reader.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/source_task/source_reader.rs
@@ -27,9 +27,9 @@ pub(in crate::stream_engine::autonomous_executor) trait SourceReader:
     ///
     /// # Failure
     ///
-    /// - [SpringError::ForeignSourceTimeout](crate::error::SpringError::ForeignSourceTimeout) when:
+    /// - `SpringError::ForeignSourceTimeout` when:
     ///   - Remote source does not provide row within timeout.
-    /// - [SpringError::ForeignIo](crate::error::SpringError::ForeignIo) when:
+    /// - `SpringError::ForeignIo` when:
     ///   - Failed to parse response from remote source.
     ///   - Unknown foreign error.
     fn next_row(&mut self) -> Result<SourceRow>;

--- a/springql-core/src/stream_engine/autonomous_executor/task/source_task/source_reader/net_client.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/source_task/source_reader/net_client.rs
@@ -27,8 +27,8 @@ pub(in crate::stream_engine) struct NetClientSourceReader {
 impl SourceReader for NetClientSourceReader {
     /// # Failure
     ///
-    /// - [SpringError::ForeignIo](crate::error::SpringError::ForeignIo)
-    /// - [SpringError::InvalidOption](crate::error::SpringError::InvalidOption)
+    /// - `SpringError::ForeignIo`
+    /// - `SpringError::InvalidOption`
     fn start(options: &Options, config: &SpringSourceReaderConfig) -> Result<Self> {
         let options = NetClientOptions::try_from(options)?;
         let sock_addr = SocketAddr::new(options.remote_host, options.remote_port);

--- a/springql-core/src/stream_engine/autonomous_executor/task/source_task/source_reader/net_server.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/source_task/source_reader/net_server.rs
@@ -34,8 +34,8 @@ pub(in crate::stream_engine) struct NetServerSourceReader {
 impl SourceReader for NetServerSourceReader {
     /// # Failure
     ///
-    /// - [SpringError::ForeignIo](crate::error::SpringError::ForeignIo)
-    /// - [SpringError::InvalidOption](crate::error::SpringError::InvalidOption)
+    /// - `SpringError::ForeignIo`
+    /// - `SpringError::InvalidOption`
     fn start(options: &Options, config: &SpringSourceReaderConfig) -> Result<Self> {
         let options = NetServerOptions::try_from(options)?;
         assert!(

--- a/springql-core/src/stream_engine/autonomous_executor/task/source_task/source_reader/source_reader_repository.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/source_task/source_reader/source_reader_repository.rs
@@ -38,7 +38,7 @@ impl SourceReaderRepository {
     ///
     /// # Failures
     ///
-    /// - [SpringError::ForeignIo](crate::error::SpringError::ForeignIo) when:
+    /// - `SpringError::ForeignIo` when:
     ///   - failed to start subtask.
     pub(in crate::stream_engine::autonomous_executor) fn register(
         &self,

--- a/springql-core/src/stream_engine/autonomous_executor/task_graph/edge_ref.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task_graph/edge_ref.rs
@@ -2,8 +2,8 @@
 
 use petgraph::graph::NodeIndex;
 
-/// Original [EdgeReference](https://docs.rs/petgraph/0.6.0/petgraph/graph/struct.EdgeReference.html) is
-/// only constructed via [edge_references()](https://docs.rs/petgraph/0.6.0/petgraph/graph/struct.Graph.html#method.edge_references)
+/// Original `EdgeReference` is
+/// only constructed via `edge_references()`
 /// traversal.
 #[derive(Clone, Eq, PartialEq, Hash, Debug, new)]
 pub(super) struct MyEdgeRef {

--- a/springql-core/src/stream_engine/in_memory_queue_repository.rs
+++ b/springql-core/src/stream_engine/in_memory_queue_repository.rs
@@ -36,7 +36,7 @@ impl InMemoryQueueRepository {
 
     /// # Failure
     ///
-    /// - [SpringError::Unavailable](crate::error::SpringError::Unavailable) when:
+    /// - `SpringError::Unavailable` when:
     ///   - queue named `queue_name` does not exist.
     pub(in crate::stream_engine) fn get(
         &self,
@@ -53,7 +53,7 @@ impl InMemoryQueueRepository {
 
     /// # Failure
     ///
-    /// - [SpringError::Sql](crate::error::SpringError::Sql) when:
+    /// - `SpringError::Sql` when:
     ///   - queue named `queue_name` already exists.
     pub(in crate::stream_engine) fn create(&self, queue_name: QueueName) -> Result<()> {
         let r = self


### PR DESCRIPTION
## Issue number and link

Related to: #180 

<!--- For bugfix, you must link to at least an issue to show clear way to reproduce the bug. -->

<!--- For new feature without any related issues, include your motivation in the next section -->

## Describe your changes

Non-pub entities do not have to have `[Name](path::to::Name)` links.
They do not appear in rustdoc.

Also, it easily causes deadlinks.

## Checklist before requesting a review

- [x] I follow the [Semantic Pull Requests](https://github.com/zeke/semantic-pull-requests) rules (bugfix/feature)
- [x] I specified links to related issues (must: bugfix, want: feature)
- [x] I have performed a self-review of my code (bugfix/feature)
- [ ] I have added thorough tests (bugfix/feature)
- [ ] I have edited `## [Unreleased]` section in `CHANGELOG.md` following [keep a changelog](https://keepachangelog.com/en/1.0.0/) syntax (bugfix/feature)
- [ ] I {made/will make} a related pull request for [documentation repo](https://github.com/SpringQL/SpringQL.github.io) (feature)
