### PR TITLE
fix: window task's ProcessedRow was zero when no pane is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All other sections are for end-users.
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+## [v0.17.2] - 2022-08-03
+
+### Fixed
+
+- GenericWorker almost always got asleep after running a window task ([#235](https://github.com/SpringQL/SpringQL/pull/235))
+
 ## [v0.17.1] - 2022-07-13
 
 ### Fixed

--- a/springql-core/src/stream_engine/autonomous_executor/task/pump_task/pump_subtask/query_subtask.rs
+++ b/springql-core/src/stream_engine/autonomous_executor/task/pump_task/pump_subtask/query_subtask.rs
@@ -109,7 +109,19 @@ pub struct QuerySubtaskOut {
 }
 impl QuerySubtaskOut {
     pub fn processed_rows(&self) -> ProcessedRows {
-        ProcessedRows::new(self.values_seq.len() as u64)
+        let by_collect = match self.in_queue_metrics_update.by_collect {
+            InQueueMetricsUpdateByCollect::Row { rows_used, .. } => rows_used,
+            InQueueMetricsUpdateByCollect::Window {
+                waiting_rows_dispatched,
+                ..
+            } => waiting_rows_dispatched,
+        };
+        let window_in_flow = self
+            .in_queue_metrics_update
+            .window_in_flow
+            .window_gain_bytes_rows;
+
+        ProcessedRows::new(by_collect + window_in_flow as u64)
     }
 }
 


### PR DESCRIPTION
## Issue number and link

Fixes: #236 

## Describe your changes

- Change the logic to calculate ProcessingRows for window tasks.

## Checklist before requesting a review

- [x] I follow the [Semantic Pull Requests](https://github.com/zeke/semantic-pull-requests) rules (bugfix/feature)
- [x] I specified links to related issues (must: bugfix, want: feature)
- [x] I have performed a self-review of my code (bugfix/feature)
- [ ] I have added thorough tests (bugfix/feature)
- [x] I have edited `## [Unreleased]` section in `CHANGELOG.md` following [keep a changelog](https://keepachangelog.com/en/1.0.0/) syntax (bugfix/feature)
- [ ] I {made/will make} a related pull request for [documentation repo](https://github.com/SpringQL/SpringQL.github.io) (feature)
