### PR TITLE
fix: Yield after submitting nc command

### DIFF
--- a/springql/examples/doc_app2.rs
+++ b/springql/examples/doc_app2.rs
@@ -34,6 +34,8 @@ fn send_data_to_pipeline() {
             .arg(cmd_text)
             .spawn()
             .expect("send failed");
+        // yield s.t. the os can execute the command and the order of the messages is upheld
+        thread::sleep(Duration::from_millis(50));
     }
 
     send_row(r#"{"ts": "2022-01-01 13:00:00.000000000", "symbol": "ORCL", "amount": 10}"#);


### PR DESCRIPTION
Up until now, it was possible that the order of messages submitted by example scripts to the pipeline was mixed up if all of the `nc` commands were submitted in one CPU processing slot. This caused the affected examples to come to wrong results.
To fix this, the processing thread is sent to sleep after each command. By doing this, the thread yields it processing time, and the `nc` command gets submitted.


## Issue number and link

Fixes #256

<!--- For bugfix, you must link to at least an issue to show clear way to reproduce the bug. -->

<!--- For new feature without any related issues, include your motivation in the next section -->

## Describe your changes

## Checklist before requesting a review

- [x] I follow the [Semantic Pull Requests](https://github.com/zeke/semantic-pull-requests) rules (bugfix/feature)
- [x] I specified links to related issues (must: bugfix, want: feature)
- [x] I have performed a self-review of my code (bugfix/feature)
- [ ] I have added thorough tests (bugfix/feature)
- [ ] I have edited `## [Unreleased]` section in `CHANGELOG.md` following [keep a changelog](https://keepachangelog.com/en/1.0.0/) syntax (bugfix/feature)
- [ ] I {made/will make} a related pull request for [documentation repo](https://github.com/SpringQL/SpringQL.github.io) (feature)
